### PR TITLE
Removes CPU usage when stopped.

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -153,7 +153,7 @@ off_t term_control(mpg123_handle *fr, out123_handle *ao)
 	do
 	{
 		off_t old_offset = offset;
-		term_handle_input(fr, ao, stopped|seeking);
+		term_handle_input(fr, ao, seeking);
 		if((offset < 0) && (-offset > framenum)) offset = - framenum;
 		if(param.verbose && offset != old_offset)
 			print_stat(fr,offset,ao,1,&param);
@@ -508,7 +508,7 @@ static void term_handle_input(mpg123_handle *fr, out123_handle *ao, int do_delay
 {
 	char val;
 	/* Do we really want that while loop? This means possibly handling multiple inputs that come very rapidly in one go. */
-	while(term_get_key(do_delay, &val))
+	while(term_get_key(stopped, do_delay, &val))
 	{
 		term_handle_key(fr, ao, val);
 	}

--- a/src/term_none.c
+++ b/src/term_none.c
@@ -25,7 +25,7 @@ void term_restore(void)
 {
 }
 
-int term_get_key(int do_delay, char *val)
+int term_get_key(int stopped, int do_delay, char *val)
 {
 	return 0;
 }

--- a/src/term_posix.c
+++ b/src/term_posix.c
@@ -176,7 +176,7 @@ int term_setup(void)
 
 /* Get the next pressed key, if any.
    Returns 1 when there is a key, 0 if not. */
-int term_get_key(int do_delay, char *val)
+int term_get_key(int stopped, int do_delay, char *val)
 {
 #ifdef __OS2__
 	KBDKEYINFO key;
@@ -184,7 +184,7 @@ int term_get_key(int do_delay, char *val)
 	key.chScan = 0;
 	if(do_delay)
 		DosSleep(10);
-	if(!KbdCharIn(&key,IO_NOWAIT,0) && key.chChar)
+	if(!KbdCharIn(&key,(stopped) ? IO_WAIT : IO_NOWAIT,0) && key.chChar)
 	{
 		*val = key.chChar;
 		return 1;
@@ -207,7 +207,8 @@ int term_get_key(int do_delay, char *val)
 
 	FD_ZERO(&r);
 	FD_SET(term_fd,&r);
-	if(select(term_fd+1,&r,NULL,NULL,&t) > 0 && FD_ISSET(term_fd,&r))
+	/* No timeout if stopped */
+	if(select(term_fd+1,&r,NULL,NULL,(stopped) ? NULL : &t) > 0 && FD_ISSET(term_fd,&r))
 	{
 		if(read(term_fd,val,1) <= 0)
 		return 0; /* Well, we couldn't read the key, so there is none. */

--- a/src/term_win32.c
+++ b/src/term_win32.c
@@ -90,7 +90,7 @@ int term_present(void){
 
 /* Get the next pressed key, if any.
    Returns 1 when there is a key, 0 if not. */
-int term_get_key(int do_delay, char *val){
+int term_get_key(int stopped, int do_delay, char *val){
   INPUT_RECORD record;
   HANDLE input;
   DWORD res;
@@ -99,7 +99,7 @@ int term_get_key(int do_delay, char *val){
   if(input == NULL || input == INVALID_HANDLE_VALUE)
     return 0;
 
-  while(WaitForSingleObject(input, do_delay ? 10 : 0) == WAIT_OBJECT_0){
+  while(WaitForSingleObject(input, stopped ? INFINITE : (do_delay ? 10 : 0)) == WAIT_OBJECT_0){
     do_delay = 0;
     if(!ReadConsoleInput(input, &record, 1, &res))
       return 0;

--- a/src/terms.h
+++ b/src/terms.h
@@ -47,6 +47,6 @@ void term_restore(void);
  *  \param val address to store character to
  *  \return 1 if there is a key, 0 if not
  */
-int term_get_key(int do_delay, char *val);
+int term_get_key(int stopped, int do_delay, char *val);
 
 #endif


### PR DESCRIPTION
Currently, mpg123 isn't idle (~0.7% CPU on my machine) when stopped.

This commit makes mpg123 just wait indefinetely for input when stopped, rather than constantly going through a full loop.

The CPU usage is now 0% when stopped.

<!--
Please write a little about the why and how of this pull request
A mail should automatically get sent to the mpg123-devel mailing list.

Before submitting, please check the following:
- [x] Set target branch to `master`
- [x] Write a little text above 
-->
