### PR TITLE
Allow building with installed mpg syn out libs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -472,7 +472,7 @@ AM_CONDITIONAL([BUILD_LIBSYN123], [ test "x$build_libsyn123" = xyes ])
 AM_CONDITIONAL([NEED_FMT123], [ test "x$build_libmpg123" = xyes || test "x$build_libout123" = xyes || test "x$build_libsyn123" = xyes ])
 # If we install libraries, prompting pkgconfig and include directories.
 AM_CONDITIONAL([NEED_LIB], [ test "x$build_libmpg123" = xyes || test "x$build_libout123" = xyes || test "x$build_libout123_modules" = xyes || test "x$build_libsyn123" = xyes ])
-AM_CONDITIONAL([NEED_MAINLIB], [ test "x$build_libmpg123" = xyes || test "x$build_libout123" = xyes || test "x$build_libsyn123" = xyes ])
+AM_CONDITIONAL([NEED_MAINLIB], [ test "x$build_libmpg123" = xyes || test "x$build_libout123" = xyes || test "x$build_libsyn123" = xyes || test "x$build_programs" = xyes ])
 
 
 if test "x$build_libmpg123" = xyes; then
@@ -2911,15 +2911,28 @@ dnl ############## Library cleanup
 
 PROG_LIBS=$LIBS
 LIBS=
-LIBMPG123_LIBS="$LIBM $COMPAT_LIBS"
-LIBSYN123_LIBS=$LIBM
-LIBOUT123_LIBS="$LIBRT $LIBM $COMPAT_LIBS"
+
+if test "x$build_libmpg123" = xyes; then
+  LIBMPG123_DEP_LIBS="$LIBM $COMPAT_LIBS"
+else
+  PKG_CHECK_MODULES(LIBMPG123, libmpg123, HAVE_LIBMPG123="yes", HAVE_LIBMPG123="no" check_failed=yes)
+fi
+if test "x$build_libsyn123" = xyes; then
+  LIBSYN123_DEP_LIBS=$LIBM
+else
+  PKG_CHECK_MODULES(LIBSYN123, libsyn123, HAVE_LIBSYN123="yes", HAVE_LIBSYN123="no" check_failed=yes)
+fi
+if test "x$build_libout123" = xyes; then
+  LIBOUT123_DEP_LIBS="$LIBRT $LIBM $COMPAT_LIBS"
+else
+  PKG_CHECK_MODULES(LIBOUT123, libout123, HAVE_LIBOUT123="yes", HAVE_LIBOUT123="no" check_failed=yes)
+fi
 
 AC_SUBST(PROG_LIBS)
 AC_SUBST(LIBM)
-AC_SUBST(LIBMPG123_LIBS)
-AC_SUBST(LIBSYN123_LIBS)
-AC_SUBST(LIBOUT123_LIBS)
+AC_SUBST(LIBMPG123_DEP_LIBS)
+AC_SUBST(LIBSYN123_DEP_LIBS)
+AC_SUBST(LIBOUT123_DEP_LIBS)
 
 dnl ############## Final Output
 
@@ -3034,8 +3047,8 @@ echo "  CFLAGS='$CFLAGS'"
 echo "  PROG_LIBS='$PROG_LIBS'"
 echo "       (derived from LIBS, only used for end-user binaries and modules)"
 echo "  LIBDL='$LIBDL'"
-echo "  LIBMPG123_LIBS='$LIBMPG123_LIBS'"
-echo "  LIBSYN123_LIBS='$LIBSYN123_LIBS'"
-echo "  LIBOUT123_LIBS='$LIBOUT123_LIBS'"
+echo "  LIBMPG123_DEP_LIBS='$LIBMPG123_DEP_LIBS'"
+echo "  LIBSYN123_DEP_LIBS='$LIBSYN123_DEP_LIBS'"
+echo "  LIBOUT123_DEP_LIBS='$LIBOUT123_DEP_LIBS'"
 echo
 echo "Next type 'make' and then 'make install'."

--- a/configure.ac
+++ b/configure.ac
@@ -440,6 +440,21 @@ AC_ARG_ENABLE(libsyn123,
   ]
 )
 
+AC_ARG_ENABLE(programs,
+  [AS_HELP_STRING([--enable-programs], [build (only) programs (with --disable-components)])],
+  [
+    if test "x$enableval" = xyes
+    then
+      build_programs=yes
+    else
+      build_programs=no
+    fi
+  ],
+  [
+    build_programs=no
+  ]
+)
+
 if test "x$build_all" = xyes; then
   build_programs=yes
   build_libmpg123=yes
@@ -447,8 +462,6 @@ if test "x$build_all" = xyes; then
   build_libout123_modules=yes
   build_libsyn123=yes
   components="programs"
-else
-  build_programs=no
 fi
 
 AM_CONDITIONAL([BUILD_PROGRAMS],  [ test "x$build_programs" = xyes ])
@@ -473,6 +486,9 @@ if test "x$build_libout123_modules" = xyes; then
 fi
 if test "x$build_libsyn123" = xyes; then
   components="$components libsyn123"
+fi
+if test "x$build_programs" = xyes; then
+  components="$components programs"
 fi
 components=$(echo $components)
 

--- a/libmpg123.pc.in
+++ b/libmpg123.pc.in
@@ -8,5 +8,5 @@ Description: An optimised MPEG Audio decoder
 Requires: 
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lmpg123 
-Libs.private: @LIBMPG123_LIBS@
+Libs.private: @LIBMPG123_DEP_LIBS@
 Cflags: -I${includedir} 

--- a/libout123.pc.in
+++ b/libout123.pc.in
@@ -8,5 +8,5 @@ Description: A streaming audio output API derived from mpg123
 Requires: 
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lout123 
-Libs.private: @LIBOUT123_LIBS@ @LIBDL@
+Libs.private: @LIBOUT123_DEP_LIBS@ @LIBDL@
 Cflags: -I${includedir} 

--- a/libsyn123.pc.in
+++ b/libsyn123.pc.in
@@ -8,5 +8,5 @@ Description: A signal synthesis library accompanying mpg123
 Requires: 
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lsyn123 
-Libs.private: @LIBSYN123_LIBS@
+Libs.private: @LIBSYN123_DEP_LIBS@
 Cflags: -I${includedir} 

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -4,10 +4,26 @@ include src/tests/Makemodule.am
 include src/compat/Makemodule.am
 include src/common/Makemodule.am
 if NEED_LIB
+if BUILD_LIBOUT123
 include src/libout123/Makemodule.am
+LIBOUT123_LINK_LIBS = src/libout123/libout123.la
+else
+LIBOUT123_LINK_LIBS = @LIBOUT123_LIBS@
+endif
 if NEED_MAINLIB
+if BUILD_LIBMPG123
 include src/libmpg123/Makemodule.am
+LIBMPG123_LINK_LIBS = src/libmpg123/libmpg123.la
+else
+LIBMPG123_LINK_LIBS = @LIBMPG123_LIBS@
+endif
+
+if BUILD_LIBSYN123
 include src/libsyn123/Makemodule.am
+LIBSYN123_LINK_LIBS = src/libsyn123/libsyn123.la
+else
+LIBSYN123_LINK_LIBS = @LIBSYN123_LIBS@
+endif
 endif
 endif
 
@@ -23,17 +39,17 @@ endif
 
 src_mpg123_LDADD = \
   src/compat/libcompat.la \
-  src/libmpg123/libmpg123.la \
-  src/libout123/libout123.la \
-  src/libsyn123/libsyn123.la \
+  ${LIBMPG123_LINK_LIBS} \
+  ${LIBOUT123_LINK_LIBS} \
+  ${LIBSYN123_LINK_LIBS} \
   @PROG_LIBS@
 
 src_mpg123_LDFLAGS = @EXEC_LT_LDFLAGS@
 
 src_out123_LDADD = \
   src/compat/libcompat.la \
-  src/libsyn123/libsyn123.la \
-  src/libout123/libout123.la \
+  ${LIBSYN123_LINK_LIBS} \
+  ${LIBOUT123_LINK_LIBS} \
   @PROG_LIBS@
 
 src_out123_LDFLAGS = @EXEC_LT_LDFLAGS@
@@ -47,12 +63,12 @@ CLEANFILES += src/*.a
 
 src_mpg123_id3dump_LDADD = \
   src/compat/libcompat.la \
-  src/libmpg123/libmpg123.la \
+  ${LIBMPG123_LINK_LIBS} \
   @PROG_LIBS@
 
 src_mpg123_strip_LDADD = \
   src/compat/libcompat.la \
-  src/libmpg123/libmpg123.la \
+  ${LIBMPG123_LINK_LIBS} \
   @PROG_LIBS@
 
 src_mpg123_SOURCES = \

--- a/src/libmpg123/Makemodule.am
+++ b/src/libmpg123/Makemodule.am
@@ -34,7 +34,7 @@ src_libmpg123_libmpg123_la_LDFLAGS = \
   -export-symbols-regex '^mpg123_'
 src_libmpg123_libmpg123_la_LIBADD = \
   src/compat/libcompat.la \
-  @LIBMPG123_LIBS@
+  @LIBMPG123_DEP_LIBS@
 src_libmpg123_libmpg123_la_DEPENDENCIES = \
   src/compat/libcompat.la
 

--- a/src/libout123/Makemodule.am
+++ b/src/libout123/Makemodule.am
@@ -55,7 +55,7 @@ src_libout123_libout123_la_LDFLAGS = \
 src_libout123_libout123_la_LIBADD = \
   src/libout123/libmodule.la \
   src/compat/libcompat.la \
-  @LIBOUT123_LIBS@
+  @LIBOUT123_DEP_LIBS@
 
 if HAVE_MODULES
 

--- a/src/libsyn123/Makemodule.am
+++ b/src/libsyn123/Makemodule.am
@@ -18,7 +18,7 @@ src_libsyn123_libsyn123_la_LDFLAGS = \
 
 src_libsyn123_libsyn123_la_LIBADD = \
   src/compat/libcompat_str.la \
-  @LIBSYN123_LIBS@
+  @LIBSYN123_DEP_LIBS@
 
 src_libsyn123_libsyn123_la_SOURCES = \
   src/libsyn123/syn123.h \


### PR DESCRIPTION
Allow building `mpg123` against installed `libmpg123`
- add `programs` component to `configure.ac`
- if building `libmpg123` is not enabled, find and use already installed `libmpg123` package; same for `libsyn123` and `libout123`
- move a few shared internal headers from `src/libmpg123` to `src/include` to fix build against installed `libmpg123` package
