### PR TITLE
streamdump: use correct dump_close function

### DIFF
--- a/src/streamdump.c
+++ b/src/streamdump.c
@@ -688,7 +688,7 @@ int dump_setup(struct stream *sd, mpg123_handle *mh)
 	if(ret != MPG123_OK)
 	{
 		error1("Unable to replace reader/open track for stream dump: %s\n", mpg123_strerror(mh));
-		dump_close(sd);
+		dump_close();
 		return -1;
 	}
 	else return 0;


### PR DESCRIPTION
The function doesn't take a parameter, so don't pass it.

Caught by Clang's -Wdeprecated-non-prototype:
```
../src/streamdump.c:691:13: error: passing arguments to 'dump_close' without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
                dump_close(sd);
                          ^
```