### PR TITLE
CMake: Only build shared libraries with position independent code

### DIFF
--- a/ports/cmake/src/compat/CMakeLists.txt
+++ b/ports/cmake/src/compat/CMakeLists.txt
@@ -2,12 +2,18 @@ set(TARGET compat)
 add_library(${TARGET} OBJECT
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../src/compat/compat.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../src/compat/compat_str.c")
-set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if(BUILD_SHARED_LIBS)
+    set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
 
 add_library(${TARGET}_dl OBJECT
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../src/compat/compat_dl.c")
-set_target_properties(${TARGET}_dl PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if(BUILD_SHARED_LIBS)
+    set_target_properties(${TARGET}_dl PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
 
 add_library(${TARGET}_str OBJECT
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../src/compat/compat_str.c")
-set_target_properties(${TARGET}_str PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if(BUILD_SHARED_LIBS)
+    set_target_properties(${TARGET}_str PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()


### PR DESCRIPTION
I would like to include the mpg123 library into PSPDEV, which is a homebrew sdk for the Playstation Portable (PSP). The PSP only supports building libraries statically, which means position independent code does not work on it. With this PR it can be build for the PSP using CMake.
