### PR TITLE
compat: do not rely on signal.h on PSP

### DIFF
--- a/src/compat/compat.c
+++ b/src/compat/compat.c
@@ -512,7 +512,7 @@ size_t INT123_unintr_fwrite(const void *ptr, size_t size, size_t nmemb, FILE *st
 }
 
 #ifndef NO_CATCHSIGNAL
-#if (!defined(WIN32) || defined (__CYGWIN__)) && defined(HAVE_SIGNAL_H)
+#if (!defined(WIN32) || defined (__CYGWIN__)) && !defined(__PSP__) && defined(HAVE_SIGNAL_H)
 void (*INT123_catchsignal(int signum, void(*handler)(int)))(int)
 {
 	struct sigaction new_sa;


### PR DESCRIPTION
The previous pull request I made, makes it possible to build for the Playstation Portable (PSP), which can be found here: https://github.com/madebr/mpg123/pull/17

This small change finishes the work needed to make libmpg123 work on the PSP. I tested it using SDL2_Mixer and it works flawlessly from what I can tell.