### PR TITLE
sysutil: fix -Wdiscarded-qualifiers warnings in strrchr assignments

### DIFF
--- a/src/sysutil.c
+++ b/src/sysutil.c
@@ -33,7 +33,7 @@ char *strndup (const char *src, int num)
 
 size_t dir_length(const char *path)
 {
-	char * slashpos = strrchr(path, '/');
+	const char * slashpos = strrchr(path, '/');
 	return (slashpos ? slashpos-path : 0);
 }
 
@@ -51,10 +51,10 @@ size_t dir_length(const char *path)
 int split_dir_file (const char *path, char **dname, char **fname)
 {
 	static char *lastdir = NULL;
-	char *slashpos;
+	const char *slashpos;
 
 	if ((slashpos = strrchr(path, '/'))) {
-		*fname = slashpos + 1;
+		*fname = (char *)(slashpos + 1);
 		*dname = INT123_compat_strdup(path); /* , 1 + slashpos - path); */
 		if(!(*dname)) {
 			perror("failed to allocate memory for dir name");


### PR DESCRIPTION
Use const char * for slashpos in dir_length() and split_dir_file() to match the constness of strrchr()'s return type when given a const char * input. Add explicit (char *) cast when storing slashpos+1 into the *fname output parameter.

<!--
Please write a little about the why and how of this pull request
A mail should automatically get sent to the mpg123-devel mailing list.

Before submitting, please check the following:
- [X] Set target branch to `master`
- [X] Write a little text above 
-->
