### PR TITLE
term: guard seq_len under #ifdef DEBUG to fix -Wunused-but-set-variable

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -601,16 +601,24 @@ static void term_handle_input(mpg123_handle *fr, out123_handle *ao, int do_delay
 		// back for real control.
 		if(val == 0x1b) // ESC, get next key, if any
 		{
+#ifdef DEBUG
 			int seq_len = 1;
+#endif
 			if(term_get_key(FALSE, -1, &val))
 			{
+#ifdef DEBUG
 				++seq_len;
+#endif
 				if(val == 'Z') // SCI, single character to drop, if any
 					term_get_key(FALSE, -1, &val);
 				else if(val == '[') // sequence begin
 				{
 					while(term_get_key(FALSE, -1, &val) && strchr("0123456789;", val))
+					{
+#ifdef DEBUG
 						++seq_len;
+#endif
+					}
 				} // else simple single-character escape
 			}
 			mdebug("dropped escape sequence of length %d", seq_len);


### PR DESCRIPTION
seq_len exists solely to feed mdebug(), which expands to noop in non-debug builds. Guard the variable declaration and its increments with #ifdef DEBUG to match the effective scope of its only consumer.

<!--
Please write a little about the why and how of this pull request
A mail should automatically get sent to the mpg123-devel mailing list.

Before submitting, please check the following:
- [X] Set target branch to `master`
- [X] Write a little text above 
-->
