### PR TITLE
httpget: fix -Wdiscarded-qualifiers in debunk_mime()

### DIFF
--- a/src/httpget.c
+++ b/src/httpget.c
@@ -118,7 +118,7 @@ int debunk_mime(const char* mime)
 	int i,j;
 	size_t len;
 	int r = 0;
-	char *aux;
+	const char *aux;
 	/* Watch out for such: "audio/x-mpegurl; charset=utf-8" */
 	aux = strchr(mime, ';');
 	if(aux != NULL)


### PR DESCRIPTION
aux is only used for pointer arithmetic and as a fprintf argument, so const char * is correct. Matches the constness of strchr()'s return type when given a const char * input.

<!--
Please write a little about the why and how of this pull request
A mail should automatically get sent to the mpg123-devel mailing list.

Before submitting, please check the following:
- [X] Set target branch to `master`
- [X] Write a little text above 
-->
