### PR TITLE
mpg123: build assembly with Clang IAS when using Clang on Windows

### DIFF
--- a/ports/cmake/src/libmpg123/CMakeLists.txt
+++ b/ports/cmake/src/libmpg123/CMakeLists.txt
@@ -64,7 +64,7 @@ add_library(${TARGET}
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../src/libmpg123/$<$<NOT:$<BOOL:${PORTABLE_API}>>:lfs_wrap.c>"
     $<TARGET_OBJECTS:compat>)
 
-if(MSVC)
+if(MSVC AND NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
     if(MACHINE MATCHES "x86|amd64")
       find_program(YASM_ASSEMBLER yasm)
       if(NOT YASM_ASSEMBLER)
@@ -214,7 +214,7 @@ target_compile_definitions(${TARGET} PRIVATE
     $<$<BOOL:${HAVE_FPU}>:REAL_IS_FLOAT>
     $<$<NOT:$<BOOL:${HAVE_FPU}>>:REAL_IS_FIXED>)
 
-if(MSVC AND MACHINE MATCHES "x86|amd64" AND YASM_ASSEMBLER)
+if(MSVC AND NOT CMAKE_C_COMPILER_ID STREQUAL "Clang" AND MACHINE MATCHES "x86|amd64" AND YASM_ASSEMBLER)
     list(TRANSFORM PLATFORM_DEFINITIONS PREPEND /D)
     foreach(FILE ${PLATFORM_SOURCES})
         get_filename_component(FILENAME ${FILE} NAME)


### PR DESCRIPTION
Unlike MSVC, Clang for Windows, including ClangCL, supports both inline and standalone assembly in GAS syntax. In that case, YASM is not needed.

Use Clang integrated assembler when targeting the MSVC ABI, but building with Clang[CL]. This not only drops the dependency on 3rd-party assembler, but may also provide better codegen in certain cases, e.g. ClangLTO.
When the picked CMake C compiler is Clang[CL], CMake automatically picks it as the compiler for GAS assembly, no adjustments needed.

Tested on Windows 11, VS 2026, and official Clang/LLVM 22.1.4, both compilation and runtime.