### PR TITLE
cmake: create libmpg123-0.dll/libout123-0.dll/libsyn123-0.dll on Windows (autotools compat)

### DIFF
--- a/ports/cmake/CMakeLists.txt
+++ b/ports/cmake/CMakeLists.txt
@@ -1,7 +1,9 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.27)
+
+set(MPG123_SOURCE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../..")
 
 include(cmake/read_api_version.cmake)
-read_api_version(MPG123_VERSION)
+read_project_version(MPG123_VERSION)
 
 project(mpg123 VERSION ${MPG123_VERSION} LANGUAGES C ASM)
 set(CMAKE_C_STANDARD 99)

--- a/ports/cmake/cmake/read_api_version.cmake
+++ b/ports/cmake/cmake/read_api_version.cmake
@@ -1,12 +1,11 @@
-function(read_api_version project_version)
+function(read_project_version project_version)
 
-    file( READ "${CMAKE_CURRENT_SOURCE_DIR}/../../src/version.h" version_h )
+    file( READ "${MPG123_SOURCE_ROOT}/src/version.h" version_h )
 
     string( REGEX MATCH "#define +MPG123_MAJOR +([0-9]+)" result ${version_h} )
     set( major_version ${CMAKE_MATCH_1})
     string( REGEX MATCH "#define +MPG123_MINOR +([0-9]+)" result ${version_h} )
     set( minor_version ${CMAKE_MATCH_1})
-
     string( REGEX MATCH "#define +MPG123_PATCH +([0-9]+)" result ${version_h} )
     set( patch_version ${CMAKE_MATCH_1})
 
@@ -15,4 +14,40 @@ function(read_api_version project_version)
 # CMake project() chokes on version with suffix, so give it just the numbers.
     set( ${project_version} ${major_version}.${minor_version}.${patch_version} PARENT_SCOPE)
 
+endfunction()
+
+function(read_mpg123_api_version soversion version)
+    file( READ "${MPG123_SOURCE_ROOT}/src/include/mpg123.h" mpg123_h )
+
+    string( REGEX MATCH "#define +MPG123_API_VERSION +([0-9]+)" result ${mpg123_h} )
+    set( api_version ${CMAKE_MATCH_1})
+    string( REGEX MATCH "#define +MPG123_PATCHLEVEL +([0-9]+)" result ${mpg123_h} )
+    set( patch_level ${CMAKE_MATCH_1})
+
+    set(${soversion} "0" PARENT_SCOPE)
+    set(${version} "0.${api_version}.${patch_level}" PARENT_SCOPE)
+endfunction()
+
+function(read_out123_api_version soversion version)
+    file( READ "${MPG123_SOURCE_ROOT}/src/include/out123.h" out123_h )
+
+    string( REGEX MATCH "#define +OUT123_API_VERSION +([0-9]+)" result ${out123_h} )
+    set( api_version ${CMAKE_MATCH_1})
+    string( REGEX MATCH "#define +OUT123_PATCHLEVEL +([0-9]+)" result ${out123_h} )
+    set( patch_level ${CMAKE_MATCH_1})
+
+    set(${soversion} "0" PARENT_SCOPE)
+    set(${version} "0.${api_version}.${patch_level}" PARENT_SCOPE)
+endfunction()
+
+function(read_syn123_api_version soversion version)
+    file( READ "${MPG123_SOURCE_ROOT}/src/include/syn123.h" syn123_h )
+
+    string( REGEX MATCH "#define +SYN123_API_VERSION +([0-9]+)" result ${syn123_h} )
+    set( api_version ${CMAKE_MATCH_1})
+    string( REGEX MATCH "#define +SYN123_PATCHLEVEL +([0-9]+)" result ${syn123_h} )
+    set( patch_level ${CMAKE_MATCH_1})
+
+    set(${soversion} "0" PARENT_SCOPE)
+    set(${version} "0.${api_version}.${patch_level}" PARENT_SCOPE)
 endfunction()

--- a/ports/cmake/src/libmpg123/CMakeLists.txt
+++ b/ports/cmake/src/libmpg123/CMakeLists.txt
@@ -204,7 +204,12 @@ elseif(MACHINE STREQUAL "generic")
     set(PLATFORM_DEFINITIONS OPT_GENERIC)
 endif()
 
+read_mpg123_api_version(mpg123_soversion mpg123_version)
 set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME mpg123)
+set_target_properties(${TARGET} PROPERTIES PREFIX lib)
+set_target_properties(${TARGET} PROPERTIES SOVERSION ${mpg123_soversion})
+set_target_properties(${TARGET} PROPERTIES VERSION ${mpg123_version})
+set_target_properties(${TARGET} PROPERTIES DLL_NAME_WITH_SOVERSION TRUE)
 
 target_compile_definitions(${TARGET} PRIVATE
     $<$<BOOL:$<TARGET_PROPERTY:POSITION_INDEPENDENT_CODE>>:PIC>)

--- a/ports/cmake/src/libout123/CMakeLists.txt
+++ b/ports/cmake/src/libout123/CMakeLists.txt
@@ -16,7 +16,12 @@ add_library(${TARGET}
     $<TARGET_OBJECTS:compat>
     $<$<BOOL:${USE_MODULES}>:$<TARGET_OBJECTS:compat_dl>>)
 
+read_out123_api_version(out123_soversion out123_version)
 set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME out123)
+set_target_properties(${TARGET} PROPERTIES PREFIX lib)
+set_target_properties(${TARGET} PROPERTIES SOVERSION ${out123_soversion})
+set_target_properties(${TARGET} PROPERTIES VERSION ${out123_version})
+set_target_properties(${TARGET} PROPERTIES DLL_NAME_WITH_SOVERSION TRUE)
 
 if(HAVE_UNIX_DL)
     string(APPEND LIBOUT123_LIBS " -ldl")

--- a/ports/cmake/src/libsyn123/CMakeLists.txt
+++ b/ports/cmake/src/libsyn123/CMakeLists.txt
@@ -13,7 +13,12 @@ add_library(${TARGET}
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../src/libsyn123/sampleconv.c"
     $<TARGET_OBJECTS:compat_str>)
 
+read_syn123_api_version(syn123_soversion syn123_version)
 set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME syn123)
+set_target_properties(${TARGET} PROPERTIES PREFIX lib)
+set_target_properties(${TARGET} PROPERTIES SOVERSION ${syn123_soversion})
+set_target_properties(${TARGET} PROPERTIES VERSION ${syn123_version})
+set_target_properties(${TARGET} PROPERTIES DLL_NAME_WITH_SOVERSION TRUE)
 
 target_include_directories(${TARGET} INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"


### PR DESCRIPTION
Building mpg123 with autotools on Windows will name the dll `libmpg123-0.dll`.
Building them with MSVC/MinGW will name them `libmpg123.dll`.

This pr adds the SOVERSION suffix to the dlls.
CMake [has a property to automatically handle this](https://cmake.org/cmake/help/latest/prop_tgt/DLL_NAME_WITH_SOVERSION.html), but it requires the minimum supported CMake version to be bumped.

